### PR TITLE
Add $listeners to component

### DIFF
--- a/src/component.vue
+++ b/src/component.vue
@@ -1,5 +1,5 @@
 <template>
-<input type="text" v-mask="config" :value="display" @input="onInput" />
+<input type="text" v-mask="config" :value="display" v-on="$listeners" @input="onInput" />
 </template>
 
 <script>


### PR DESCRIPTION
Hi!
I added `$listeners` to TheMask component for simple handling events with dynamic components.
At the moment, when using dynamic components, it is possible to handle events of only one type -`event` for native input or `event.native` for TheMask component.
After added `$listeners`, its example may be possible:
```vue
<template>
  <div class="ui-input">
    <component 
      type="text"
      :is="dynamicInput"
      v-bind="{ mask }"
      @focus="hasFocus = true"  <!-- works with native input and TheMask comp. -->
    >
  <div/>
</template>

<script>
import { TheMask } from 'vue-the-mask';

export default {
  name: 'ui-input',
  data() {
    return {
      hasFocus: false,
    };
  },
  props: {
    mask: {
      type: [Array, String],
      default() {
        return null;
      },
    },
  },
  computed: {
    dynamicInput() {
      return (this.mask) ? 'TheMask' : 'input';
    },
  },
  components: {
    TheMask,
  },
}
</script>
```


