### PR TITLE
Updated IBAN mask

### DIFF
--- a/src/docs/docs.vue
+++ b/src/docs/docs.vue
@@ -53,7 +53,7 @@
     <div class="equal width fields">
       <div class="field">
         <label>IBAN {{iban}}</label>
-        <the-mask mask="AA## #### #### #### #### #### ###" v-model="iban" :masked="masked"></the-mask>
+        <the-mask mask="AA## XXXX XXXX XXXX XXXX XXXX XXXX XXXX XX" v-model="iban" :masked="masked"></the-mask>
       </div>
 
       <div class="field">


### PR DESCRIPTION
According to below sources, IBAN numbers are a maximum of 34 characters and always start with two letters and two digits (ex. NL08).
The BBAN (after the first four characters) can be case-insensitive alphanumeric. This commit fixes the mask in the documentation to allow for these variations.

Sources: 
https://en.wikipedia.org/wiki/International_Bank_Account_Number
https://www.iban.com/structure.html