### PR TITLE
Add information to disable the vue-mask directive

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,12 @@ export default {
 '!': {escape: true}
 ```
 
+## Disable v-mask directive
+
+```
+<input type="tel" v-mask="null" />
+```
+
 ![The Mask Money](https://raw.githubusercontent.com/vuejs-tips/vue-the-mask/master/img/the-mask-hammer.gif)
 
 ## Properties


### PR DESCRIPTION
I needed to use the vue-mask on a custom input component. I didn't always want to use the vue-mask in my input fields, and in order not to use a `v-if` with `v-else` just to make another input without the v-mask directive, I had to keep testing to deactivate the `v-mask=""`. This component of mine receives a props called mask that I added in: `v-mask="mask"` and I was unsure how to disable the `v-mask`. Nowhere in the documentation did I find this information to disable v-mask, so I found it useful to add this to the read-me. At first I thought that using only `""` empty string would work, in fact it was just using `null`, leaving as a final result: `v-mask="null"`.