### PR TITLE
doc: add example for advanced directive usage

### DIFF
--- a/src/docs/docs.vue
+++ b/src/docs/docs.vue
@@ -167,6 +167,11 @@
       <input type="tel" placeholder="dd/mm/yyyy" />
     </div>
     <pre>{{directive}}</pre>
+    
+    <div class="field" v-mask="directiveMask">
+      <input type="tel" placeholder="987 BC" />
+    </div>
+    <pre>{{directiveAdvanced}}</pre>
 
     <div class="ui tertiary inverted red segment">
       The value returned from directive is always masked!
@@ -201,7 +206,25 @@ export default {
       placeholder: 'test your mask here',
       mask: '#XSAa',
       value: '12TgB',
-      directive: `<input type="tel" v-mask="'##/##/####'" />`
+      directive: `<input type="tel" v-mask="'##/##/####'" />`,
+      directiveMask: {
+        mask: "### YY",
+        tokens: {
+          Y: {
+            pattern: /[0-9A-C]/,
+          },
+          "#": { pattern: /\d/ },
+        },
+      }
+      directiveAdvanced: `<input type="tel" v-mask="{
+        mask: "### YY",
+        tokens: {
+          Y: {
+            pattern: /[0-9A-C]/,
+          },
+          "#": { pattern: /\d/ },
+        },
+      }" />`
     }
   },
   computed: {


### PR DESCRIPTION
Update the website documentation to include a directive advanced usage.

As mentioned in this issue https://github.com/vuejs-tips/vue-the-mask/issues/48#issue-280045671 the directive can be used with an `object` rather than a `string`.