### PR TITLE
Add repo URL on package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
   ],
   "author": "Marcos Neves <marcos.neves@gmail.com> (https://vuejs-tips.github.io/)",
   "license": "MIT",
+  "repository": "https://github.com/vuejs-tips/vue-the-mask",
   "babel": {
     "env": {
       "test": {


### PR DESCRIPTION
I was looking at npm and noticed the repository URL was missing.
https://www.npmjs.com/package/vue-the-mask